### PR TITLE
docs: Fix naming consistency issues in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,52 @@
 # Nerves.WpaSupplicant
 [![Build Status](https://travis-ci.org/nerves-project/nerves_wpa_supplicant.svg?branch=master)](https://travis-ci.org/nerves-project/nerves_wpa_supplicant)
 
-This package enables Elixir applications to interact with the local WPA
-supplicant. The WPA supplicant handles various Wi-Fi operations like scanning
-for wireless networks, connecting, authenticating, and collecting wireless
-adapter statistics.
+This package enables Elixir applications to query or effect changes on Wi-Fi
+network connections of a host system, by interacting with a [wireless
+supplicant].
 
-*This library is under development and we plan on making the API more user friendly in future versions*
+The portable [wpa_supplicant] daemon handles Wi-Fi operations like scanning for
+wireless networks, connecting, authenticating, and collecting wireless adapter
+statistics. `Nerves.WpaSupplicant` uses the control interface provided by this
+supplicant implementation to bring these capabilities to your Elixir code.
+
+*This library is under development and we plan on making the API more user-friendly in future versions.*
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
-
-  1. Add nerves_wpa_supplicant to your list of dependencies in `mix.exs`:
+1. Add `nerves_wpa_supplicant` to your list of dependencies in `mix.exs`:
 
         def deps do
           [{:nerves_wpa_supplicant, "~> 0.2.1"}]
         end
 
-  2. Ensure nerves_wpa_supplicant is started before your application:
+2. Ensure `nerves_wpa_supplicant` is started before your application:
 
         def application do
           [applications: [:nerves_wpa_supplicant]]
         end
 
-
 ## Note on permissions
 
-The `nerves_wpa_supplicant` daemon runs as root and requires processes that attach to
-its control interface to be root. This project contains a C port process whose
-sole purpose is to interact with the `nerves_wpa_supplicant` daemon, but it needs
-sufficient permission to do so. The `Makefile` contains logic to mark the port
-process setuid root so that this works, but you may want to change this
+The `wpa_supplicant` daemon runs as root and requires processes that attach to
+its control interface to be root. This project contains a C port process—called
+`wpa_ex`—whose sole purpose is to interact with the `wpa_supplicant` daemon,
+but it needs sufficient permission to do so. The `Makefile` contains logic to
+mark `wpa_ex` setuid root so that this works, but you may want to change this
 depending on your setup.
 
 ## Building
 
-Building `nerves_wpa_supplicant` is similar to other Elixir projects. The Makefile
-will invoke `mix` to compile both the Elixir and C source code. The only extra
-step is to ensure that the permissions are right on the `wpa_ex` binary. The
-way this is accomplished is by setting `wpa_ex` setuid root. By default, when
-you run `make`, you'll be asked your password to change permissions.
+Building `nerves_wpa_supplicant` is similar to other Elixir projects. The
+`Makefile` will invoke `mix` to compile both the Elixir and C source code. The
+only additional step is to ensure that permissions are suitable on the `wpa_ex`
+binary as described in the preceding section. You'll be asked for your password
+for this step when you run `make`, by default.
 
     $ make
 
 If you want to disable the setuid root step in the Makefile, just set the `SUDO`
-environment variable to `true` to make it a nop:
+environment variable to `true` to make it a no-op:
 
     $ SUDO=true make
 
@@ -55,16 +56,16 @@ If you need to use a different askpass program, you can set that as well:
 
 ## Running
 
-The `nerves_wpa_supplicant` daemon must be running already on your system and the control
+The `wpa_supplicant` daemon must be running already on your system and the control
 interface must be exposed. If you have any doubt, try running `wpa_cli`. If that
 doesn't work, the Elixir `Nerves.WpaSupplicant` won't work.
 
-If you're on a system where you can start the `nerves_wpa_supplicant` manually, here's
+If you're on a system where you can start the `wpa_supplicant` manually, here's
 an example command line:
 
     $ /sbin/wpa_supplicant -iwlan0 -C/var/run/wpa_supplicant -B
 
-Once you're happy that the `nerves_wpa_supplicant` is running, start `iex` by running:
+Once you're happy that the `wpa_supplicant` is running, start `iex` by running:
 
     $ iex -S mix
 
@@ -73,10 +74,10 @@ Start a `Nerves.WpaSupplicant` process:
     iex> {:ok, pid} = Nerves.WpaSupplicant.start_link("/var/run/wpa_supplicant/wlan0")
     {:ok, #PID<0.82.0>}
 
-You can sanity check that Elixir has properly attached to the `nerves_wpa_supplicant`
+You can sanity-check that Elixir has properly attached to the `wpa_supplicant`
 daemon by pinging the daemon:
 
-    iex> WpaSupplicant.request(pid, :PING)
+    iex> Nerves.WpaSupplicant.request(pid, :PING)
     :PONG
 
 To scan for access points, call `Nerves.WpaSupplicant.scan/1`. This can take a few
@@ -97,15 +98,14 @@ seconds:
        level: -43, noise: 0, qual: 0, ssid: "dlink", tsf: 580587711245}]
 
 To attach to an access point, you need to configure a network entry in the
-`nerves_wpa_supplicant`. The `nerves_wpa_supplicant` can have multiple network entries
+`wpa_supplicant`. The `wpa_supplicant` can have multiple network entries
 configured. The following removes all network entries so that only one is
-configured.
+configured:
 
     iex> Nerves.WpaSupplicant.set_network(pid, ssid: "MyNetworkSsid", key_mgmt: :WPA_PSK, psk: "secret")
     :ok
 
-
-If the access point is around, the `nerves_wpa_supplicant` will eventually connect to
+If the access point is around, the `wpa_supplicant` will eventually connect to
 the network.
 
     iex> Nerves.WpaSupplicant.status(pid)
@@ -113,10 +113,11 @@ the network.
       group_cipher: "TKIP", id: 0, key_mgmt: "WPA2-PSK", mode: "station",
       pairwise_cipher: "CCMP", ssid: "MyNetworkSsid", wpa_state: "COMPLETED"}
 
-Polling the `nerves_wpa_supplicant` for status isn't that great, so it's possible to
-register a `GenEvent` with `NervesWpaSupplicant`. If you don't supply one in the call
-to `start_link`, one is automatically created and available via `WpaSupplicant.event_manager/1`. The
-following example shows how to view events at the prompt:
+Polling the `wpa_supplicant` for status isn't ideal, so it's possible to
+register a `GenEvent` with `Nerves.WpaSupplicant`. If you don't supply one with
+a call to `start_link/2`, one is automatically created and available via
+`Nerves.WpaSupplicant.event_manager/1`. The following example shows how to view
+events at the prompt:
 
     iex> defmodule Forwarder do
     ...>  use GenEvent
@@ -125,17 +126,17 @@ following example shows how to view events at the prompt:
     ...>    {:ok, parent}
     ...>  end
     ...> end
-    iex> NervesWpaSupplicant.event_manager(pid) |> GenEvent.add_handler(Forwarder, self())
+    iex> Nerves.WpaSupplicant.event_manager(pid) |> GenEvent.add_handler(Forwarder, self())
     iex> flush
     {:nerves_wpa_supplicant, #PID<0.85.0>, :"CTRL-EVENT-SCAN-STARTED"}
     {:nerves_wpa_supplicant, #PID<0.85.0>, :"CTRL-EVENT-SCAN-RESULTS"}
 
-## Low level messaging
+## Low-level messaging
 
-It is expected that the helper functions for interacting with the `nerves_wpa_supplicant`
+It is expected that the helper functions for interacting with the `wpa_supplicant`
 will not cover every situation. The `Nerves.WpaSupplicant.request/2` function allows
 you to send arbitrary commands. Requests are atoms that are named the same as
-described in the `nerves_wpa_supplicant` documentation (see Useful links). If a request
+described in the `wpa_supplicant` documentation (see *Useful links*). If a request
 takes a parameter, pass it as a tuple where the first element is the command.
 Parameters may be strings or numbers and will be properly formatted for the
 control interface. The response is also parsed and turned into atoms, numbers,
@@ -150,14 +151,15 @@ care of by this library. Here are some examples:
 
 ## Useful links
 
-  1. [wpa_supplicant homepage](http://w1.fi/wpa_supplicant/)
-  2. [wpa_supplicant control interface](http://w1.fi/wpa_supplicant/devel/ctrl_iface_page.html)
-  3. [wpa_supplicant information on the archlinux wiki](https://wiki.archlinux.org/index.php/Wpa_supplicant)
+  1. [API Reference](https://hexdocs.pm/nerves_wpa_supplicant/api-reference.html)
+  2. [wpa_supplicant homepage][wpa_supplicant]
+  3. [wpa_supplicant control interface](http://w1.fi/wpa_supplicant/devel/ctrl_iface_page.html)
+  4. [wpa_supplicant information on the archlinux wiki](https://wiki.archlinux.org/index.php/Wpa_supplicant)
 
 ## Licensing
 
 The majority of this package is licensed under the Apache 2.0 license. The code
-that directly interfaces with the `nerves_wpa_supplicant` is copied from the
+that directly interfaces with the `wpa_supplicant` is copied from the
 `wpa_supplicant` package and has the following copyright and license:
 
 ```
@@ -169,3 +171,6 @@ that directly interfaces with the `nerves_wpa_supplicant` is copied from the
  * See README for more details.
  */
 ```
+
+[wireless supplicant]: https://en.wikipedia.org/wiki/Wireless_supplicant
+[wpa_supplicant]: http://w1.fi/wpa_supplicant/

--- a/lib/nerves_wpa_supplicant.ex
+++ b/lib/nerves_wpa_supplicant.ex
@@ -90,19 +90,19 @@ defmodule Nerves.WpaSupplicant do
   the most useful. The full list can be found in the wpa_supplicant
   documentation. Here's a list of some common ones:
 
-  Option                | Description
-  ----------------------|------------
-  :ssid                 | Network name. This is mandatory.
-  :key_mgmt             | The security in use. This is mandatory. Set to :NONE, :WPA_PSK
-  :proto                | Protocol use use. E.g., :WPA2
-  :psk                  | WPA preshared key. 8-63 chars or the 64 char one as processed by `wpa_passphrase`
-  :bssid                | Optional BSSID. If set, only associate with the AP with a matching BSSID
-  :mode                 | Mode: 0 = infrastructure (default), 1 = ad-hoc, 2 = AP
-  :frequency            | Channel frequency. e.g., 2412 for 802.11b/g channel 1
-  :wep_key0..3          | Static WEP key
-  :wep_tx_keyidx        | Default WEP key index (0 to 3)
+      Option                | Description
+      ----------------------|------------
+      :ssid                 | Network name. This is mandatory.
+      :key_mgmt             | The security in use. This is mandatory. Set to :NONE, :WPA_PSK
+      :proto                | Protocol use use. E.g., :WPA2
+      :psk                  | WPA preshared key. 8-63 chars or the 64 char one as processed by `wpa_passphrase`
+      :bssid                | Optional BSSID. If set, only associate with the AP with a matching BSSID
+      :mode                 | Mode: 0 = infrastructure (default), 1 = ad-hoc, 2 = AP
+      :frequency            | Channel frequency. e.g., 2412 for 802.11b/g channel 1
+      :wep_key0..3          | Static WEP key
+      :wep_tx_keyidx        | Default WEP key index (0 to 3)
 
-  Note that this is a helper function that wraps several low level calls and
+  Note that this is a helper function that wraps several low-level calls and
   is limited to specifying only one network at a time. If you'd
   like to register multiple networks with the supplicant, send the
   ADD_NETWORK, SET_NETWORK, SELECT_NETWORK messages manually.
@@ -165,7 +165,7 @@ defmodule Nerves.WpaSupplicant do
 
   def handle_call({:request, command}, from, state) do
     payload = Messages.encode(command)
-    Logger.info("NervesWpaSupplicant: sending '#{payload}'")
+    Logger.info("Nerves.WpaSupplicant: sending '#{payload}'")
     send state.port, {self, {:command, payload}}
     state = %{state | :requests => state.requests ++ [{from, command}]}
     {:noreply, state}


### PR DESCRIPTION
The text _mostly_ seemed to hard-wrap around 80ish columns, so I tried to maintain that. As such, GitHub's prose diff feature may come in handy.

There were a few things that slowed my comprehension when finding this project:
1. Numerous instances of `nerves_wpa_supplicant` in the README were actually referring to the `wpa_supplicant` daemon. Seems like a search-and-replace oversight. These made an important distinction harder to understand.
2. "WPA supplicant" is a pretty esoteric phrase. In this change I've tried to state _what_ the package does foremost, in terms of value to the user. Involvement of the supplicant is the secondary _how_.
   
    On first reading I wanted a definition of this term near the start. The link to the `wpa_supplicant` homepage was given much later, and the opening text of that page is acronym overload that still doesn't define the general term. Wikipedia is concisely helpful in this case, I think.
3. There were a couple of small naming changes missed in the code samples. Minor, but distracting and fixable.

While we're at it, I noticed an ASCII table in the module docs that renders as a mess on HexDocs. I'm not sure if the Markdown parser supports any of the table extension syntaxes, but at the least making it preformatted should make it readable.
